### PR TITLE
Fix 6450

### DIFF
--- a/src/Wt/WMenuItem.C
+++ b/src/Wt/WMenuItem.C
@@ -388,7 +388,7 @@ void WMenuItem::selectNotLoaded()
 
 bool WMenuItem::contentsLoaded() const
 {
-  return uContents_ != nullptr;
+  return oContents_.operator bool();
 }
 
 void WMenuItem::loadContents()


### PR DESCRIPTION
For the first loaded WMenuItem, loadContents() was executed before connectSignals() and moved uContents_ out. As a result, a call to implementStateless() was missing. 
After this change, the tab will now able to be switched after the application is killed.